### PR TITLE
Fixing name length issue

### DIFF
--- a/src/DOMComponents/Table.js
+++ b/src/DOMComponents/Table.js
@@ -52,6 +52,12 @@ export default class Table extends DOMComponent {
       .replace(/\]/g, ')')
       .replace(/(\?|\*)/g, '');
 
+    sheetName = cleanSheetName(sheetName);
+
+    if (sheetName.length > 28) {
+      sheetName = sheetName.substring(0, 29);
+    }
+
     const createSheetName = (name, number) => {
       const fullname = `${name} ${number}`;
       if (changedWorkBook.SheetNames.indexOf(fullname) < 0) {
@@ -63,7 +69,7 @@ export default class Table extends DOMComponent {
     if (changedWorkBook.SheetNames.indexOf(sheetName) >= 0) {
       sheetName = createSheetName(sheetName, 2);
     }
-    sheetName = cleanSheetName(sheetName);
+
     const worksheet = XLSX.utils.aoa_to_sheet(table);
 
     changedWorkBook.SheetNames.push(sheetName);

--- a/test/Table.test.js
+++ b/test/Table.test.js
@@ -154,6 +154,28 @@ describe('Table', () => {
       expect(newWorkbook.Sheets['Table-One (small)'].A1.v).toBe('h1');
     });
 
+    it('should create a document with a longer than 30 char name and correct it', () => {
+      const workbook = XLSX.utils.book_new();
+      const component = DocFlux.render(
+        <table>
+          <tname>*Table/One [small] areallyreallyreallyreallylongname?</tname>
+          <thead>
+            <th>h1</th>
+          </thead>
+          <tbody>
+            <tr>
+              <td>d1</td>
+            </tr>
+          </tbody>
+        </table>,
+        Parser,
+      );
+
+      const newWorkbook = DocFlux.transform(component, workbook);
+      expect(newWorkbook.SheetNames[0]).toBe('Table-One (small) areallyreal');
+      expect(newWorkbook.Sheets['Table-One (small) areallyreal'].A1.v).toBe('h1');
+    });
+
     it('should create a document with a number as a value and an empty header', () => {
       const workbook = XLSX.utils.book_new();
       const component = DocFlux.render(


### PR DESCRIPTION
Chops names off at 29 characters.  This allows for a space and a number to follow (in case pagination is needed).

closes #4